### PR TITLE
Fixed HE.net authentication & domain not found error message variable.

### DIFF
--- a/certbot-he-hook.sh
+++ b/certbot-he-hook.sh
@@ -56,7 +56,8 @@ if [ -n "$HE_USER" ] && [ -n "$HE_PASS" ]; then
   HE_COOKIE=$( \
     curl -L --silent --show-error -I "https://dns.he.net/" \
       | grep '^Set-Cookie:' \
-      | grep -Eo 'CGISESSID=[a-z0-9]*')
+      | cut -c 13- \
+      | cut -d\; -f 1)
   # Attempt login
   curl -L --silent --show-error --cookie "$HE_COOKIE" \
     --form "email=${HE_USER}" \

--- a/certbot-he-hook.sh
+++ b/certbot-he-hook.sh
@@ -95,7 +95,7 @@ while true; do
 
   # All possible zone names have been tried
   if [ -z "$ATTEMPTED_ZONE" ]; then
-    echo "No zone for domain \"$DOMAIN\" found." 1>&2
+    echo "No zone for domain \"$CERTBOT_DOMAIN\" found." 1>&2
     return 1
   fi
 


### PR DESCRIPTION
My domains didn't auto renew and when I went to investigate it seems like Hurricane Electric no longer has "CGISESSID" in their cookie variable. SESSID logins are likely broken but this pull fixes logins using your username and password.