### PR TITLE
Fix an error the script generated.

### DIFF
--- a/certbot-he-hook.sh
+++ b/certbot-he-hook.sh
@@ -96,7 +96,7 @@ while true; do
   # All possible zone names have been tried
   if [ -z "$ATTEMPTED_ZONE" ]; then
     echo "No zone for domain \"$DOMAIN\" found." 1>&2
-    return 1
+    continue
   fi
 
   # Take care of "." and only match whole lines. Note that grep -F


### PR DESCRIPTION
Can't use "return" at this location -- not in a function.  Also, return probably wouldn't be the right choice anyway.  Replaced it with continue.